### PR TITLE
don't publish .babelrc to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ node_modules
 *.log
 .directory
 .editorconfig
+.babelrc


### PR DESCRIPTION
Prevents errors when simply using the npm package like 'Unknown plugin "transform-runtime"'