### PR TITLE
Implement support for directly exporting classes and functions and some other variants

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["es2015"],
-  "plugins": ["transform-runtime"],
+  "presets": ["@babel/preset-env"],
+  "plugins": ["@babel/plugin-transform-runtime"]
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "none",
+  "bracketSpacing": false,
+  "jsxBracketSameLine": true,
+  "arrowParens": "avoid",
+  "proseWrap": "preserve"
+}

--- a/package.json
+++ b/package.json
@@ -6,16 +6,16 @@
   "license": "MIT",
   "main": "dist/index.js",
   "dependencies": {
-    "babel-runtime": "^6.3.19",
+    "@babel/runtime": "^7.6.3",
     "better-log": "^1.3.1",
-    "babel-template": "^6.3.13"
+    "@babel/template": "^7.6.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.3.17",
-    "babel-core": "^6.3.21",
-    "babel-plugin-transform-runtime": "^6.3.13",
-    "babel-preset-es2015": "^6.5.0",
-    "babel-register": "^6.3.13",
+    "@babel/cli": "^7.6.4",
+    "@babel/core": "^7.6.4",
+    "@babel/plugin-transform-runtime": "^7.6.2",
+    "@babel/preset-env": "^7.6.3",
+    "@babel/register": "^7.6.2",
     "chalk": "^1.1.0",
     "clear": "0.0.1",
     "diff": "^1.4.0",
@@ -25,7 +25,7 @@
     "release": "babel src --out-dir dist",
     "test": "node test",
     "watch": "node test --watch",
-	"prepublish": "npm test && npm run release"
+    "prepublish": "npm test && npm run release"
   },
   "keywords": [
     "babel-plugin",

--- a/src/index.js
+++ b/src/index.js
@@ -1,85 +1,258 @@
-import 'better-log/install';
-import template from "babel-template";
+import "better-log/install";
+import template from "@babel/template";
 
-let buildModule = template(`
-define([IMPORT_PATHS], function(IMPORT_VARS) {
+const buildModule = template(`
+define(IMPORT_PATHS, function(IMPORT_VARS) {
 	NAMED_IMPORTS;
 	BODY;
 });
 `);
 
-module.exports = function({ types: t }) {
-	return {
-		visitor: {
-			Program: {
-				exit(path, file) {
-					let body = path.get("body"),
-						sources = [],
-						anonymousSources = [],
-						vars = [],
-						namedImports = [],
-						isModular = false,
-						middleDefaultExportID = false;
+export default function transformToAmd({types: t}) {
+  return {
+    visitor: {
+      Program: {
+        exit(programPath) {
+          const bodyPaths = programPath.get("body");
+          const sources = [];
+          const anonymousSources = [];
+          const vars = [];
+          const namedImports = [];
+          let isModular = false;
+          let defaultExportExpression = null;
 
-					for (let i = 0; i < body.length; i++) {
-						let path = body[i],
-							isLast = i == body.length - 1;
+          for (let i = 0; i < bodyPaths.length; i++) {
+            const isLastBodyStatement = i === bodyPaths.length - 1;
+            const bodyStatementPath = bodyPaths[i];
 
-						if (path.isExportDefaultDeclaration()) {
-							let declaration = path.get("declaration");
+            if (t.isExportNamedDeclaration(bodyStatementPath)) {
+							// console.log("named export");
 
-							if(isLast) {
-								path.replaceWith(t.returnStatement(declaration.node));
-							} else {
-								middleDefaultExportID = path.scope.generateUidIdentifier("export_default");
-								path.replaceWith(t.variableDeclaration('var', [t.variableDeclarator(middleDefaultExportID, declaration.node)]));
-							}
+              const {specifiers} = bodyStatementPath.node;
+              let j = specifiers.length;
+              while (j--) {
+                const specifier = specifiers[j];
+                if (
+                  t.isExportSpecifier(specifier) &&
+                  specifier.exported.name === "default"
+                ) {
+                  // import -> export
+                  // export {name as default, ...};
+                  // export { default } from ....;
+                  // export { default as default } from ....;
+                  
+                  // Not supported:
+                  // export {name as default, ...} from ....; 
 
-							isModular = true;
-						}
+                  if(specifier.local.name === "default") {
+                    // console.log("export { default as default, ... } from ...;");
+                    defaultExportExpression = bodyStatementPath.scope.generateUidIdentifier(
+                      bodyStatementPath.node.source.value
+                    );
+                    sources.push(bodyStatementPath.node.source);
+                    vars.push(defaultExportExpression);
+                  } else if(bodyStatementPath.node.source) {
+                    // console.log(`export { ${specifier.local.name} as default, ... } from ...;`);
+                    throw new Error("Named imports are not supported.");
+                  } else {
+                    // console.log(`export { ${specifier.local.name} as default, ... };`);
+                    defaultExportExpression = specifier.local;
+                  }
+                  specifiers.splice(j, 1);
+                  isModular = true;
+                  break;
+                } else if (t.isExportDefaultSpecifier(specifier)) {
+                  // console.log("export { default } from ...;");
+                  defaultExportExpression = specifier.exported;
+                  specifiers.splice(j, 1);
+                  isModular = true;
+                  break;
+                }
+              }
 
-						if (path.isImportDeclaration()) {
-							let specifiers = path.node.specifiers;
+              if (specifiers.length === 0) {
+                bodyStatementPath.remove();
+              }
+            } else if (t.isExportDefaultDeclaration(bodyStatementPath)) {
+							// console.log("export default x;");
 
-							if(specifiers.length == 0) {
-								anonymousSources.push(path.node.source);
-							} else if(specifiers.length == 1 && specifiers[0].type == 'ImportDefaultSpecifier') {
-								sources.push(path.node.source);
-								vars.push(specifiers[0]);
-							} else {
-								let importedID = path.scope.generateUidIdentifier(path.node.source.value);
-								sources.push(path.node.source);
-								vars.push(importedID);
+              // Check if a variable is needed. Yes if:
+              // - it's a function declaration
+              // - it's a class declaration
+              // - it's an expression, which could, in principle, be embedded in
+              //   the return declaration, however, not if this is not the last
+              //   body statement.
+              const declaration = bodyStatementPath.get("declaration");
+              if (
+                t.isFunctionDeclaration(declaration) ||
+                t.isClassDeclaration(declaration)
+              ) {
+                // Does the class or function have a name?
+                if (declaration.node.id !== null) {
+                  // > export default class foo { ... };
 
-								specifiers.forEach(({imported, local}) => {
-									namedImports.push(t.variableDeclaration("var", [
-										t.variableDeclarator(t.identifier(local.name), t.identifier(importedID.name + '.' + imported.name))
-									]));
-								});
-							}
+									// console.log("Named class or function isFun=" + t.isFunctionDeclaration(declaration));
 
-							path.remove();
+                  // Replace the export with the actual declaration.
+                  // > class foo { ... };
+                  bodyStatementPath.replaceWith(declaration.node);
 
-							isModular = true;
-						}
+                  // The return value will be the name of the class or function.
+                  defaultExportExpression = declaration.node.id;
+                } else {
+                  // > export default class { ... };
 
-						if(isLast && middleDefaultExportID) {
-							path.insertAfter(t.returnStatement(middleDefaultExportID));
-						}
-					}
+									// console.log("Anonymous class or function isFun=" + t.isFunctionDeclaration(declaration));
 
-					if(isModular) {
-						path.node.body = [
-							buildModule({
-								IMPORT_PATHS: sources.concat(anonymousSources),
-								IMPORT_VARS: vars,
-								BODY: path.node.body,
-								NAMED_IMPORTS: namedImports
-							})
-						];
-					}
-				}
-			}
-		}
-	};
+                  // Need a variable to capture the class or function, as an expression.
+                  // > var export_default = class { ... };
+
+                  const varName = createDefaultExportVarName(bodyStatementPath.scope);
+
+                  // The variable will contain the anonymous declaration, but as an expression.
+                  const varValue = declaration.node;
+
+                  // Change the declaration to a corresponding expression.
+                  varValue.type = t.isFunctionDeclaration(declaration)
+                    ? "FunctionExpression"
+                    : "ClassExpression";
+
+                  const variable = createVariable(t, varName, varValue);
+
+                  bodyStatementPath.replaceWith(variable);
+
+									// The variable will be the function's return value.
+									// > return export_default;
+                  defaultExportExpression = varName;
+                }
+              } else if (!isLastBodyStatement) {
+								// console.log("expression, not last in body");
+                // An expression that needs to be captured as a variable.
+
+                // Need a variable to capture the class or function, as an expression.
+                // > var export_default = class { ... };
+
+								const varName = createDefaultExportVarName(bodyStatementPath.scope);
+
+								// The variable will contain the expression.
+								const varValue = declaration.node;
+
+                const variable = createVariable(t, varName, varValue);
+
+                bodyStatementPath.replaceWith(variable);
+
+								// The variable will be the function's return value.
+								// > return export_default;
+                defaultExportExpression = varName;
+              } else {
+								// console.log("expression, last in body");
+								// > export default <expression>;
+								// convert to:
+								// > return <expression>;
+
+                bodyStatementPath.remove();
+                defaultExportExpression = declaration.node;
+              }
+
+              isModular = true;
+            } else if (t.isImportDeclaration(bodyStatementPath)) {
+              const {specifiers} = bodyStatementPath.node;
+
+              if (specifiers.length === 0) {
+                anonymousSources.push(bodyStatementPath.node.source);
+              } else if (
+                specifiers.length === 1 &&
+                specifiers[0].type === "ImportDefaultSpecifier"
+              ) {
+                sources.push(bodyStatementPath.node.source);
+                vars.push(specifiers[0].local);
+              } else {
+                
+                // Should not be supported this way, imo.
+
+                const importedID = bodyStatementPath.scope.generateUidIdentifier(
+                  bodyStatementPath.node.source.value
+                );
+                sources.push(bodyStatementPath.node.source);
+                vars.push(importedID);
+
+                specifiers.forEach(({imported, local}) => {
+                  namedImports.push(
+                    t.variableDeclaration("var", [
+                      t.variableDeclarator(
+                        t.identifier(local.name),
+                        t.identifier(importedID.name + "." + imported.name)
+                      )
+                    ])
+                  );
+                });
+              }
+
+              bodyStatementPath.remove();
+
+              isModular = true;
+            }
+
+            if (isLastBodyStatement && defaultExportExpression !== null) {
+              // Output the `return defaultExport;` statement.
+              // Done within the loop to have access to `bodyStatementPath`.
+
+              // Cannot insertAfter a removed node.
+              // Find the previous node which is not removed.
+              const returnStatement = t.returnStatement(
+                defaultExportExpression
+              );
+              const closestBeforePath = findClosestNonRemovedBefore(
+                bodyStatementPath,
+                i,
+                bodyPaths
+              );
+
+              if (closestBeforePath !== null) {
+                closestBeforePath.insertAfter(returnStatement);
+              } else {
+                programPath.unshiftContainer("body", [returnStatement]);
+              }
+            }
+          }
+
+          if (isModular) {
+            programPath.node.body = [
+              buildModule({
+                IMPORT_PATHS: t.arrayExpression(
+                  sources.concat(anonymousSources)
+                ),
+                IMPORT_VARS: vars,
+                BODY: programPath.node.body,
+                NAMED_IMPORTS: namedImports
+              })
+            ];
+          }
+        }
+      }
+    }
+  };
 };
+
+function createDefaultExportVarName(scope) {
+  return scope.generateUidIdentifier("export_default");
+}
+
+function createVariable(t, id, valueExpression) {
+  return t.variableDeclaration("var", [
+    t.variableDeclarator(id, valueExpression)
+  ]);
+}
+
+function findClosestNonRemovedBefore(path, pathIndex, siblingPaths) {
+  // Cannot insertAfter a removed node...
+
+  // Find the previous node which is not removed.
+  let refPath = path;
+  let i = pathIndex;
+  while (refPath.removed && i > 0) {
+    refPath = siblingPaths[--i];
+  }
+
+  return refPath.removed ? null : refPath;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -227,6 +227,16 @@ export default function transformToAmd({types: t}) {
                 NAMED_IMPORTS: namedImports
               })
             ];
+
+            const isStrict = programPath.node.directives.some(
+              directive => directive.value.value === "use strict"
+            );
+            if (!isStrict) {
+              programPath.unshiftContainer(
+                "directives",
+                t.directive(t.directiveLiteral("use strict"))
+              );
+            }
           }
         }
       }

--- a/test/fixtures/basic/expected.js
+++ b/test/fixtures/basic/expected.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 define(['/path/to/a', '/path/to/c', '/path/to/e', '/path/to/k', '/path/to/b', '/path/to/d'], function (a, c, _pathToE, _pathToK) {
   var e = _pathToE.e;

--- a/test/fixtures/class_anonymous_last/actual.js
+++ b/test/fixtures/class_anonymous_last/actual.js
@@ -1,0 +1,7 @@
+import a from '/path/to/a';
+import '/path/to/b';
+import c from '/path/to/c';
+import '/path/to/d';
+import e from '/path/to/e';
+doSomething();
+export default class {}

--- a/test/fixtures/class_anonymous_last/expected.js
+++ b/test/fixtures/class_anonymous_last/expected.js
@@ -1,0 +1,11 @@
+"use strict";
+
+define(["@babel/runtime/helpers/classCallCheck", '/path/to/a', '/path/to/c', '/path/to/e', '/path/to/b', '/path/to/d'], function (_classCallCheck, a, c, e) {
+  doSomething();
+  
+  var _default = function _default() {
+    _classCallCheck(this, _default);
+  };
+  
+  return _default;
+});

--- a/test/fixtures/class_anonymous_not_last/actual.js
+++ b/test/fixtures/class_anonymous_not_last/actual.js
@@ -1,0 +1,8 @@
+import a from '/path/to/a';
+import '/path/to/b';
+import c from '/path/to/c';
+import '/path/to/d';
+import e from '/path/to/e';
+doSomething();
+export default class {}
+doSomethingElse();

--- a/test/fixtures/class_anonymous_not_last/expected.js
+++ b/test/fixtures/class_anonymous_not_last/expected.js
@@ -1,0 +1,13 @@
+"use strict";
+
+define(["@babel/runtime/helpers/classCallCheck", '/path/to/a', '/path/to/c', '/path/to/e', '/path/to/b', '/path/to/d'], function (_classCallCheck, a, c, e) {
+  doSomething();
+  
+  var _default = function _default() {
+    _classCallCheck(this, _default);
+  };
+
+  doSomethingElse();
+
+  return _default;
+});

--- a/test/fixtures/class_named_last/actual.js
+++ b/test/fixtures/class_named_last/actual.js
@@ -1,0 +1,7 @@
+import a from '/path/to/a';
+import '/path/to/b';
+import c from '/path/to/c';
+import '/path/to/d';
+import e from '/path/to/e';
+doSomething();
+export default class Foo {}

--- a/test/fixtures/class_named_last/expected.js
+++ b/test/fixtures/class_named_last/expected.js
@@ -1,0 +1,11 @@
+"use strict";
+
+define(["@babel/runtime/helpers/classCallCheck", '/path/to/a', '/path/to/c', '/path/to/e', '/path/to/b', '/path/to/d'], function (_classCallCheck, a, c, e) {
+  doSomething();
+  
+  var Foo = function Foo() {
+    _classCallCheck(this, Foo);
+  };
+
+  return Foo;
+});

--- a/test/fixtures/class_named_not_last/actual.js
+++ b/test/fixtures/class_named_not_last/actual.js
@@ -1,0 +1,8 @@
+import a from '/path/to/a';
+import '/path/to/b';
+import c from '/path/to/c';
+import '/path/to/d';
+import e from '/path/to/e';
+doSomething();
+export default class Foo {}
+doSomethingElse();

--- a/test/fixtures/class_named_not_last/expected.js
+++ b/test/fixtures/class_named_not_last/expected.js
@@ -1,0 +1,13 @@
+"use strict";
+
+define(["@babel/runtime/helpers/classCallCheck", '/path/to/a', '/path/to/c', '/path/to/e', '/path/to/b', '/path/to/d'], function (_classCallCheck, a, c, e) {
+  doSomething();
+  
+  var Foo = function Foo() {
+    _classCallCheck(this, Foo);
+  };
+
+  doSomethingElse();
+
+  return Foo;
+});

--- a/test/fixtures/export_default_from/actual.js
+++ b/test/fixtures/export_default_from/actual.js
@@ -1,0 +1,2 @@
+const a = {};
+export { default } from "path/to/x";

--- a/test/fixtures/export_default_from/expected.js
+++ b/test/fixtures/export_default_from/expected.js
@@ -1,0 +1,6 @@
+"use strict";
+
+define(["path/to/x"], function (_pathToX) {
+  var a = {};
+  return _pathToX;
+});

--- a/test/fixtures/export_default_from_not_last/actual.js
+++ b/test/fixtures/export_default_from_not_last/actual.js
@@ -1,0 +1,3 @@
+const a = {};
+export { default } from "path/to/x";
+foo(a);

--- a/test/fixtures/export_default_from_not_last/expected.js
+++ b/test/fixtures/export_default_from_not_last/expected.js
@@ -1,0 +1,7 @@
+"use strict";
+
+define(["path/to/x"], function (_pathToX) {
+  var a = {};
+  foo(a);
+  return _pathToX;
+});

--- a/test/fixtures/export_name_as_default/actual.js
+++ b/test/fixtures/export_name_as_default/actual.js
@@ -1,0 +1,2 @@
+const a = {};
+export {a as default};

--- a/test/fixtures/export_name_as_default/expected.js
+++ b/test/fixtures/export_name_as_default/expected.js
@@ -1,0 +1,6 @@
+"use strict";
+
+define([], function () {
+  var a = {};
+  return a;
+});

--- a/test/fixtures/export_name_as_default_from/actual.js
+++ b/test/fixtures/export_name_as_default_from/actual.js
@@ -1,0 +1,2 @@
+const a = {};
+export { x as default } from "path/to/x";

--- a/test/fixtures/export_name_as_default_not_last/actual.js
+++ b/test/fixtures/export_name_as_default_not_last/actual.js
@@ -1,0 +1,3 @@
+const a = {};
+export {a as default};
+foo(a);

--- a/test/fixtures/export_name_as_default_not_last/expected.js
+++ b/test/fixtures/export_name_as_default_not_last/expected.js
@@ -1,0 +1,7 @@
+"use strict";
+
+define([], function () {
+  var a = {};
+  foo(a);
+  return a;
+});

--- a/test/fixtures/function_anonymous_last/actual.js
+++ b/test/fixtures/function_anonymous_last/actual.js
@@ -1,0 +1,7 @@
+import a from '/path/to/a';
+import '/path/to/b';
+import c from '/path/to/c';
+import '/path/to/d';
+import e from '/path/to/e';
+doSomething();
+export default function() {}

--- a/test/fixtures/function_anonymous_last/expected.js
+++ b/test/fixtures/function_anonymous_last/expected.js
@@ -2,7 +2,8 @@
 
 define(['/path/to/a', '/path/to/c', '/path/to/e', '/path/to/b', '/path/to/d'], function (a, c, e) {
   doSomething();
-  var _export_default = x + y;
-  doSomethingElse();
+  
+  var _export_default = function () {};
+
   return _export_default;
 });

--- a/test/fixtures/function_anonymous_not_last/actual.js
+++ b/test/fixtures/function_anonymous_not_last/actual.js
@@ -1,0 +1,8 @@
+import a from '/path/to/a';
+import '/path/to/b';
+import c from '/path/to/c';
+import '/path/to/d';
+import e from '/path/to/e';
+doSomething();
+export default function() {}
+doSomethingElse();

--- a/test/fixtures/function_anonymous_not_last/expected.js
+++ b/test/fixtures/function_anonymous_not_last/expected.js
@@ -2,7 +2,10 @@
 
 define(['/path/to/a', '/path/to/c', '/path/to/e', '/path/to/b', '/path/to/d'], function (a, c, e) {
   doSomething();
-  var _export_default = x + y;
+  
+  var _export_default = function () {};
+
   doSomethingElse();
+
   return _export_default;
 });

--- a/test/fixtures/function_named_last/actual.js
+++ b/test/fixtures/function_named_last/actual.js
@@ -1,0 +1,7 @@
+import a from '/path/to/a';
+import '/path/to/b';
+import c from '/path/to/c';
+import '/path/to/d';
+import e from '/path/to/e';
+doSomething();
+export default function Foo() {}

--- a/test/fixtures/function_named_last/expected.js
+++ b/test/fixtures/function_named_last/expected.js
@@ -2,7 +2,8 @@
 
 define(['/path/to/a', '/path/to/c', '/path/to/e', '/path/to/b', '/path/to/d'], function (a, c, e) {
   doSomething();
-  var _export_default = x + y;
-  doSomethingElse();
-  return _export_default;
+  
+  function Foo() {}
+
+  return Foo;
 });

--- a/test/fixtures/function_named_not_last/actual.js
+++ b/test/fixtures/function_named_not_last/actual.js
@@ -1,0 +1,8 @@
+import a from '/path/to/a';
+import '/path/to/b';
+import c from '/path/to/c';
+import '/path/to/d';
+import e from '/path/to/e';
+doSomething();
+export default function Foo() {}
+doSomethingElse();

--- a/test/fixtures/function_named_not_last/expected.js
+++ b/test/fixtures/function_named_not_last/expected.js
@@ -2,7 +2,10 @@
 
 define(['/path/to/a', '/path/to/c', '/path/to/e', '/path/to/b', '/path/to/d'], function (a, c, e) {
   doSomething();
-  var _export_default = x + y;
+  
+  function Foo() {}
+
   doSomethingElse();
-  return _export_default;
+
+  return Foo;
 });


### PR DESCRIPTION
In part, this PR fixes https://github.com/finom/babel-plugin-transform-es2015-modules-simple-amd/issues/9.

It adds support for:
- `export default class Foo {}`
- `export default class {}`
- `export default function Foo {}`
- `export default function {}`
- `export {default} from X`
- `export {foo as default}`

The form `export {foo as default} from X` was explicitly left out (and throws). This is an export of a named import, and I don't think named imports should be supported at all, just like named exports are not supported. Unfortunately, it seems that the current implementation accepts named imports as being properties of the default export. I did not change that, but did not add more to it.

I could not test the class forms directly, because with the current babel settings they are being transpiled before.

Finally, I updated babel packages to the latest 7.X versions.